### PR TITLE
Fix duplicate UIPanel opening on 'Open Project' action

### DIFF
--- a/src/activeSegmentation/gui/CreateOpenProjectGUI.java
+++ b/src/activeSegmentation/gui/CreateOpenProjectGUI.java
@@ -116,8 +116,8 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 					System.out.println(" GuiPanel ");
 					new GuiPanel(projectManager);
 					
-					UIPanel frame=new UIPanel(projectManager);
-					frame.setVisible(true);
+//					UIPanel frame=new UIPanel(projectManager);
+//					frame.setVisible(true);
 				}
 				else 
 					IJ.error("Not a project file!");


### PR DESCRIPTION
To fix this, I have commented out the redundant lines of code responsible for opening the second UIPanel window.