### PR TITLE
fix: remove duplicate .classpath entry and add missing db/model file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,11 @@
 *.xref
 /.temp-Active_Segmentation_-classpathOnly-1581890621933.jar
 .classpath
-.classpath
-.classpath
 .idea/
 *.iml
 resources/META-INF/
+*.db
+*.dbs
+*.dbs.bak
+*.sqbpro
 


### PR DESCRIPTION
## What this PR does
- Removes duplicate `.classpath` entry that appeared 3 times in .gitignore
- Adds missing patterns for database and model files:
  - `*.db` — SQLite database files
  - `*.dbs` — feature model database files
  - `*.dbs.bak` — backup files
  - `*.sqbpro` — SQLite browser project files

## Why
These files are auto-generated or experimental and should not be tracked 
in version control as they can cause confusion for new contributors.