### PR TITLE
Fix: replace unsafe '==' comparisons with '.equals()' for ActionEvent and Strings

### DIFF
--- a/src/activeSegmentation/gui/CreateOpenProjectGUI.java
+++ b/src/activeSegmentation/gui/CreateOpenProjectGUI.java
@@ -119,11 +119,11 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 	private static File currentDir=null;
 
 	private void doAction( final ActionEvent event ){
-		if(event ==CREATE_BUTTON_PRESSED ){
+		if(CREATE_BUTTON_PRESSED.equals(event) ){
 			cardLayout.show(cardPanel, "createProjectPanel");
 		}
 
-		if(event ==OPEN_BUTTON_PRESSED ){
+		if(OPEN_BUTTON_PRESSED.equals(event) ){
 			JFileChooser fileChooser = new JFileChooser();
 
 			// For Directory
@@ -157,7 +157,7 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 			}
 		}
 
-		if(event== BROWSE_BUTTON_PRESSED){
+		if(BROWSE_BUTTON_PRESSED.equals(event)){
 			JFileChooser fileChooser = new JFileChooser();
 
 			// For Directory
@@ -169,7 +169,7 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 			}
 		}
 
-		if(event== TRAININGF_BUTTON_PRESSED){
+		if(TRAININGF_BUTTON_PRESSED.equals(event)){
 			JFileChooser fileChooser = new JFileChooser();
 
 			// For Directory
@@ -181,7 +181,7 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 			}
 		}
 
-		if(event== Tiff_BUTTON_PRESSED){
+		if(Tiff_BUTTON_PRESSED.equals(event)){
 			JFileChooser fileChooser = new JFileChooser();
 
 			// For Directory
@@ -193,7 +193,7 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 			}
 		}
 
-		if(event== TESTINGF_BUTTON_PRESSED){
+		if( TESTINGF_BUTTON_PRESSED.equals(event)){
 			JFileChooser fileChooser = new JFileChooser();
 
 			// For Directory
@@ -206,7 +206,7 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 			//}
 		}
 
-		if (event == CANCEL_BUTTON_PRESSED) {
+		if (CANCEL_BUTTON_PRESSED.equals(event)) {
 			// Reset fields or perform any necessary cleanup
 			projectNField.setText("");
 			projectDField.setText("");
@@ -220,7 +220,7 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 		}
 
 		// Creating project structure
-		if(event== FINISH_BUTTON_PRESSED){
+		if( FINISH_BUTTON_PRESSED.equals(event)){
 			String projectName=projectNField.getText();
 			String projectDirectory=projectFField.getText();
 			String projectDescription=projectDField.getText();
@@ -261,18 +261,18 @@ public class CreateOpenProjectGUI implements Runnable, ASCommon {
 			}
 		}
 
-		if (event == BACK_BUTTON_PRESSED) {
+		if ( BACK_BUTTON_PRESSED.equals(event)) {
 			cardLayout.show(cardPanel, "mainPanel"); // Switch back to the main panel
 			nextButton.setVisible(true);
 			exitButton.setVisible(true);
 		}
 
-		if (event == NEXT_BUTTON_PRESSED) {
+		if (NEXT_BUTTON_PRESSED.equals(event)) {
 			cardLayout.show(cardPanel, "createProjectPanel"); // Switch to the create project panel
 		}
 
 		// Confirm Exit
-		if (event == EXIT_BUTTON_PRESSED) {
+		if (EXIT_BUTTON_PRESSED.equals(event)) {
 			int response = javax.swing.JOptionPane.showConfirmDialog(mainFrame, "Are you sure you want to exit?", "Confirm Exit",
 					javax.swing.JOptionPane.YES_NO_OPTION, javax.swing.JOptionPane.QUESTION_MESSAGE);
 			if (response == javax.swing.JOptionPane.YES_OPTION) {

--- a/src/activeSegmentation/gui/FeaturePanel.java
+++ b/src/activeSegmentation/gui/FeaturePanel.java
@@ -565,7 +565,7 @@ public class FeaturePanel extends ImageWindow implements Runnable, ASCommon, IUt
 			updateGui();
 		} // end if
 		
-		if(event == PREVIOUS_BUTTON_PRESSED){			
+		if(PREVIOUS_BUTTON_PRESSED.equals(event)){			
 			ImagePlus image=featureManager.getPreviousImage();
 			imageNum.setText(Integer.toString(featureManager.getCurrentSlice()));
 			loadImage(image);

--- a/src/activeSegmentation/gui/FilterPanel.java
+++ b/src/activeSegmentation/gui/FilterPanel.java
@@ -363,7 +363,7 @@ public class FilterPanel extends JFrame implements Runnable, ASCommon {
 				updateFilterList();
 			}
 		}
-		if(event == PREVIOUS_BUTTON_PRESSED ){
+		if(PREVIOUS_BUTTON_PRESSED.equals(event) ){
 			int currentIndex = pane.getSelectedIndex();
 			if (currentIndex > 0) {
 				pane.setSelectedIndex(currentIndex - 1);

--- a/src/activeSegmentation/gui/GuiPanel.java
+++ b/src/activeSegmentation/gui/GuiPanel.java
@@ -64,7 +64,7 @@ public class GuiPanel extends JFrame implements ASCommon {
 	}
 
 	public void doAction(ActionEvent event) 	{
-		if ((event == this.FILTER_BUTTON_PRESSED)) {
+		if (this.FILTER_BUTTON_PRESSED.equals(event)) {
 			//if(this.filterPanel == null) {
 			// for time being feature manager is passed , will think
 			// of better design later
@@ -73,28 +73,28 @@ public class GuiPanel extends JFrame implements ASCommon {
 			SwingUtilities.invokeLater(filterPanel);
 		}
 
-		if(event==this.FILTERVIS_BUTTON_PRESSED){
+		if(this.FILTERVIS_BUTTON_PRESSED.equals(event)){
 			//if (this.filterOutputPanel==null) {
 			filterOutputPanel=new ViewFilterOutputPanel(projectManager,featureManager);
 			//}
 			SwingUtilities.invokeLater(this.filterOutputPanel);
 		}
 
-		if ((event == this.FEATURE_BUTTON_PRESSED)) {
+		if (this.FEATURE_BUTTON_PRESSED.equals(event)) {
 			//if (this.featurePanel == null) {
 			featurePanel=new FeaturePanel(featureManager);
 			//}
 			SwingUtilities.invokeLater(this.featurePanel);
 		}
 
-		if (event == this.LEARNING_BUTTON_PRESSED)	{
+		if (this.LEARNING_BUTTON_PRESSED.equals(event))	{
 			//if (this.learningPanel == null) {
 			learningPanel = new LearningPanel(projectManager, learningManager);
 			//}
 			SwingUtilities.invokeLater(learningPanel);
 		}
 
-		if (event == this.EVALUATION_BUTTON_PRESSED) {
+		if (this.EVALUATION_BUTTON_PRESSED.equals(event)) {
 			//if (evaluationPanel==null) {
 			evaluationPanel = new EvaluationPanel(projectManager, null);
 			//}
@@ -102,11 +102,11 @@ public class GuiPanel extends JFrame implements ASCommon {
 
 		}
 
-		if (event == this.SESSIONGUI_BUTTON_PRESSED) {
+		if (this.SESSIONGUI_BUTTON_PRESSED.equals(event)) {
 			new SessionGUI(projectManager); // Create and display the SessionGUI instance
 		}
 
-		if (event == this.VISUALIZATION_BUTTON_PRESSED) {
+		if (this.VISUALIZATION_BUTTON_PRESSED.equals(event)) {
 			SwingUtilities.invokeLater(() -> {
 				JFrame frame = new JFrame("Visualization Panel");
 				frame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
@@ -117,13 +117,13 @@ public class GuiPanel extends JFrame implements ASCommon {
 			});
 		}
 
-		if (event == this.BACK_BUTTON_PRESSED) {
+		if (this.BACK_BUTTON_PRESSED.equals(event)) {
 			mainFrame.dispose(); // Close the current window
 			new CreateOpenProjectGUI(projectManager).run(); // Reopen the main window
 		}
 
 		// Confirm Exit
-		if (event == this.EXIT_BUTTON_PRESSED) {
+		if (this.EXIT_BUTTON_PRESSED.equals(event)) {
 			int response = JOptionPane.showConfirmDialog(mainFrame, "Are you sure you want to exit?", "Confirm Exit",
 					JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
 			if (response == JOptionPane.YES_OPTION) {

--- a/src/activeSegmentation/gui/LearningPanel.java
+++ b/src/activeSegmentation/gui/LearningPanel.java
@@ -99,7 +99,7 @@ public class LearningPanel extends JFrame implements Runnable, ASCommon {
    * @param event
    */
   public void doAction(ActionEvent event)  {
-    if (event == SAVE_BUTTON_PRESSED)     {
+    if (SAVE_BUTTON_PRESSED.equals(event))     {
       updateClassifier();    
       if (aclass!=null ) {
     	  IClassifier classifier = new WekaClassifier(aclass);
@@ -115,7 +115,7 @@ public class LearningPanel extends JFrame implements Runnable, ASCommon {
       }
      
     } // end SAVE
-    if (event == LOAD_BUTTON_PRESSED)     {
+    if (LOAD_BUTTON_PRESSED.equals(event))     {
     	LearningInfo li=learningManager.getLearningMetaData();
     	String[] options= li.getOptionsArray();
   
@@ -123,7 +123,7 @@ public class LearningPanel extends JFrame implements Runnable, ASCommon {
     	System.out.println("loading "+cname);
     	//GuiUtil.printStringArray(options);
     	try {
-    		if (cname!="") {
+    		if (cname.isEmpty()) {
     			// TODO change into loadClass from  TestLoadClass 
 				aclass = (AbstractClassifier) Class.forName(cname).newInstance();
 				//cls.setOptions(options);		

--- a/src/activeSegmentation/gui/ViewFilterOutputPanel.java
+++ b/src/activeSegmentation/gui/ViewFilterOutputPanel.java
@@ -404,7 +404,7 @@ public class ViewFilterOutputPanel extends ImageWindow implements Runnable, IUti
 
 	public void doAction( final ActionEvent event )	{
 
-		if(event == PREVIOUS_BUTTON_PRESSED && featureNum >1){
+		if(PREVIOUS_BUTTON_PRESSED.equals(event) && featureNum >1){
 
 			//System.out.println("BUTTON PRESSED");
 			featureNum=featureNum-1;

--- a/src/activeSegmentation/learning/ClassifierManager.java
+++ b/src/activeSegmentation/learning/ClassifierManager.java
@@ -237,7 +237,7 @@ public class ClassifierManager extends URLClassLoader implements ASCommon, IClas
 			LocalDateTime trainingEndTime;
 			
 			trainingStartTime = LocalDateTime.now();
-			if (cname!="")  {			
+			if (cname.isEmpty())  {			
 			 	IFeatureSelection cclass =featureMap.get(cname);
 			 	if (dataset==null) {
 			 		IJ.log("Classifier Manager: error in training:"+ cclass.getName() +" is null");
@@ -353,7 +353,7 @@ public class ClassifierManager extends URLClassLoader implements ASCommon, IClas
 			System.out.println("learning option "+ cname);
 			ApplyTask applyTask=null;
 			IDataSet fdata=null;
-			if (cname!="")  {
+			if (cname.isEmpty())  {
 				IFeatureSelection filter =featureMap.get(cname);
 				System.out.print("Classifier Manager: selecting feature " +filter. getName()+ " "+cname);
 				//fdata=filter.selectFeatures(dataSet);


### PR DESCRIPTION
## Description

This PR fixes incorrect comparisons of `ActionEvent` and `String` objects across multiple GUI classes.

## Changes

* Replaced `==` with `.equals()` for `ActionEvent` comparisons to ensure correct value-based equality
* Replaced string comparison using `!= ""` with `!cname.isEmpty()`

## Why this matters

Using `==` compares object references instead of values, which can cause UI actions to fail unexpectedly.
These changes improve correctness and reliability of event handling.

